### PR TITLE
Fix padding on decode.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -63,15 +63,24 @@
                  (unless (eq character #\.)
                    (write-char character out))))))))
 
+
+(defun add-padding (base-64-string)
+  (let* ((block-size 4)
+         (num-chars-to-add (- block-size (rem (length base-64-string)
+                                              block-size))))
+    (if (= num-chars-to-add block-size)
+        base-64-string
+        (concatenate 'string
+                     base-64-string
+                     (make-array num-chars-to-add
+                                 :element-type 'character
+                                 :initial-element #\.)))))
+
 (defun base64-decode (base-64-string)
   "Takes a base64-uri string and return an array of octets"
   (base64-string-to-usb8-array
    ;; Re-pad the string, or CL-BASE64 will get confused
-   (concatenate 'string
-                base-64-string
-                (make-array (rem (length base-64-string) 4)
-                            :element-type 'character
-                            :initial-element #\.))
+   (add-padding base-64-string)
    :uri t))
 
 (defun issue (claims &key algorithm secret issuer subject audience


### PR DESCRIPTION
Before this fix, a library wasn't able to decode some tokens it created.

Here is a small example:

```lisp
PASSPORT/CLIENT> (cl-json-web-tokens:issue (serapeum:dict "user-id" 100500) :algorithm :hs256 :secret "foo" :issued-at (get-universal-time)) "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyLWlkIjoxMDA1MDAsImlhdCI6MTY2Njg4MDc3OH0.-ybwjcVfjmnwahjHP6Mx30lAAe5VA7T5KqcGazAqIIc" PASSPORT/CLIENT> (cl-json-web-tokens:decode * :secret "foo") ; Debugger entered on #<CL-BASE64:BAD-BASE64-CHARACTER {100A718593}> [1] PASSPORT/CLIENT>
; Evaluation aborted on #<CL-BASE64:BAD-BASE64-CHARACTER {100A718593}>
```

All because base64 padding was calculated incorrectly.